### PR TITLE
fix hard-coded values in multiplication timeindex and resolution

### DIFF
--- a/src/multiharp_toolkit/cmd.py
+++ b/src/multiharp_toolkit/cmd.py
@@ -37,6 +37,7 @@ def measure():
             }
         ]
         * 16,
+        # TODO: Neet to include "globRes" for StreamParser
     }
 
     dev = Device(dev_ids[0], config)

--- a/src/multiharp_toolkit/cmd.py
+++ b/src/multiharp_toolkit/cmd.py
@@ -37,7 +37,7 @@ def measure():
             }
         ]
         * 16,
-        # TODO: Need to include "globRes" for StreamParser
+        # TODO: Need to include "time_resolution" for StreamParser
     }
 
     dev = Device(dev_ids[0], config)

--- a/src/multiharp_toolkit/cmd.py
+++ b/src/multiharp_toolkit/cmd.py
@@ -37,7 +37,7 @@ def measure():
             }
         ]
         * 16,
-        # TODO: Neet to include "globRes" for StreamParser
+        # TODO: Need to include "globRes" for StreamParser
     }
 
     dev = Device(dev_ids[0], config)

--- a/src/multiharp_toolkit/cmd.py
+++ b/src/multiharp_toolkit/cmd.py
@@ -37,7 +37,6 @@ def measure():
             }
         ]
         * 16,
-        # TODO: Need to include "time_resolution" for StreamParser
     }
 
     dev = Device(dev_ids[0], config)

--- a/src/multiharp_toolkit/ptu_parser.py
+++ b/src/multiharp_toolkit/ptu_parser.py
@@ -47,7 +47,7 @@ class Parser:
         self.channels = []
         self.timestamps = []
         self.combined_channel = False
-        self.globRes = 5  # TODO: Neet to get from "MeasDesc_GlobalResolution"
+        self.globRes = 5  # TODO: Need to get from "MeasDesc_GlobalResolution"
 
     def __repr__(self) -> str:
         num_ev_str = ",".join(

--- a/src/multiharp_toolkit/ptu_parser.py
+++ b/src/multiharp_toolkit/ptu_parser.py
@@ -47,6 +47,7 @@ class Parser:
         self.channels = []
         self.timestamps = []
         self.combined_channel = False
+        self.globRes = 5  # TODO: Neet to get from "MeasDesc_GlobalResolution"
 
     def __repr__(self) -> str:
         num_ev_str = ",".join(
@@ -98,12 +99,17 @@ class Parser:
             truetime = self.oflcorrection + timetag
             self.append_events(channel + 1, truetime)
 
+    def timeidx2time(self, timeidx: float) -> float:
+        """convert time index to time(unit: psec)
+        """
+        return timeidx * self.globRes
+
     def append_events(self, channel: int, timestamp: float):
         if self.combined_channel:
             self.channels.append(channel)
-            self.timestamps.append(timestamp * 5)
+            self.timestamps.append(self.timeidx2time(timestamp))
         else:
-            self.events[channel].append(timestamp * 5)
+            self.events[channel].append(self.timeidx2time(timestamp))
 
 
 def parse_header(inputfile: io.BufferedReader):

--- a/src/multiharp_toolkit/ptu_parser.py
+++ b/src/multiharp_toolkit/ptu_parser.py
@@ -47,7 +47,7 @@ class Parser:
         self.channels = []
         self.timestamps = []
         self.combined_channel = False
-        self.time_resolution = 5  # TODO: Need to get from "MeasDesc_GlobalResolution"
+        self.time_resolution = 5
 
     def __repr__(self) -> str:
         num_ev_str = ",".join(

--- a/src/multiharp_toolkit/ptu_parser.py
+++ b/src/multiharp_toolkit/ptu_parser.py
@@ -34,7 +34,7 @@ class Parser:
     events: list[list[int | float]]  # [channel: [timetag]]
     timestamps: list[float]  # for combined channel mode
     channels: list[int]  # for combined channel mode
-    oflcorrection: float
+    oflcorrection: int
     ptu_version: int
     T2WRAPAROUND_V1 = 33552000
     T2WRAPAROUND_V2 = 33554432
@@ -99,12 +99,12 @@ class Parser:
             truetime = self.oflcorrection + timetag
             self.append_events(channel + 1, truetime)
 
-    def timetag2time(self, timetag: float) -> float:
+    def timetag2time(self, timetag: int) -> int:
         """convert time tag to time(unit: psec)
         """
         return timetag * self.time_resolution
 
-    def append_events(self, channel: int, timestamp: float):
+    def append_events(self, channel: int, timestamp: int):
         if self.combined_channel:
             self.channels.append(channel)
             self.timestamps.append(self.timetag2time(timestamp))

--- a/src/multiharp_toolkit/ptu_parser.py
+++ b/src/multiharp_toolkit/ptu_parser.py
@@ -99,7 +99,7 @@ class Parser:
             truetime = self.oflcorrection + timetag
             self.append_events(channel + 1, truetime)
 
-    def timetag2time(self, timetag: int) -> int:
+    def convert_timetag_to_relative_timestamp(self, timetag: int) -> int:
         """convert time tag to time(unit: psec)
         """
         return timetag * self.time_resolution
@@ -107,9 +107,9 @@ class Parser:
     def append_events(self, channel: int, timestamp: int):
         if self.combined_channel:
             self.channels.append(channel)
-            self.timestamps.append(self.timetag2time(timestamp))
+            self.timestamps.append(self.convert_timetag_to_relative_timestamp(timestamp))
         else:
-            self.events[channel].append(self.timetag2time(timestamp))
+            self.events[channel].append(self.convert_timetag_to_relative_timestamp(timestamp))
 
 
 def parse_header(inputfile: io.BufferedReader):

--- a/src/multiharp_toolkit/ptu_parser.py
+++ b/src/multiharp_toolkit/ptu_parser.py
@@ -47,7 +47,7 @@ class Parser:
         self.channels = []
         self.timestamps = []
         self.combined_channel = False
-        self.globRes = 5  # TODO: Need to get from "MeasDesc_GlobalResolution"
+        self.time_resolution = 5  # TODO: Need to get from "MeasDesc_GlobalResolution"
 
     def __repr__(self) -> str:
         num_ev_str = ",".join(
@@ -99,17 +99,17 @@ class Parser:
             truetime = self.oflcorrection + timetag
             self.append_events(channel + 1, truetime)
 
-    def timeidx2time(self, timeidx: float) -> float:
-        """convert time index to time(unit: psec)
+    def timetag2time(self, timetag: float) -> float:
+        """convert time tag to time(unit: psec)
         """
-        return timeidx * self.globRes
+        return timetag * self.time_resolution
 
     def append_events(self, channel: int, timestamp: float):
         if self.combined_channel:
             self.channels.append(channel)
-            self.timestamps.append(self.timeidx2time(timestamp))
+            self.timestamps.append(self.timetag2time(timestamp))
         else:
-            self.events[channel].append(self.timeidx2time(timestamp))
+            self.events[channel].append(self.timetag2time(timestamp))
 
 
 def parse_header(inputfile: io.BufferedReader):

--- a/src/multiharp_toolkit/stream_parser.py
+++ b/src/multiharp_toolkit/stream_parser.py
@@ -35,7 +35,7 @@ class StreamParser:
         self.oflcorrection = 0
         self.config = None
         self.single_file = single_file
-        self.globRes = 5  # TODO: Neet to get from MultiHarp settings
+        self.globRes = 5  # TODO: Need to get from MultiHarp settings
 
     async def run(self):
         while True:

--- a/src/multiharp_toolkit/stream_parser.py
+++ b/src/multiharp_toolkit/stream_parser.py
@@ -35,7 +35,7 @@ class StreamParser:
         self.oflcorrection = 0
         self.config = None
         self.single_file = single_file
-        self.time_resolution = 5  # TODO: Need to get from MultiHarp settings
+        self.time_resolution = 5
 
     async def run(self):
         while True:

--- a/src/multiharp_toolkit/stream_parser.py
+++ b/src/multiharp_toolkit/stream_parser.py
@@ -35,7 +35,7 @@ class StreamParser:
         self.oflcorrection = 0
         self.config = None
         self.single_file = single_file
-        self.globRes = 5  # TODO: Need to get from MultiHarp settings
+        self.time_resolution = 5  # TODO: Need to get from MultiHarp settings
 
     async def run(self):
         while True:
@@ -71,11 +71,11 @@ class StreamParser:
                         if channel == 0:  # sync
                             truetime = self.oflcorrection + timetag
                             ch_arr.append(channel)
-                            ts_arr.append(self.timeidx2time(truetime))
+                            ts_arr.append(self.timetag2time(truetime))
                     else:  # regular input channel
                         truetime = self.oflcorrection + timetag
                         ch_arr.append(channel + 1)
-                        ts_arr.append(self.timeidx2time(truetime))
+                        ts_arr.append(self.timetag2time(truetime))
             if ch_arr:
                 batch = pa.record_batch(
                     [
@@ -90,10 +90,10 @@ class StreamParser:
                 ts_arr = []
             self.queue_recv.task_done()
 
-    def timeidx2time(self, timeidx: float) -> float:
-        """convert time index to time(unit: psec)
+    def timetag2time(self, timetag: float) -> float:
+        """convert time tag to time(unit: psec)
         """
-        return timeidx * self.globRes
+        return timetag * self.time_resolution
 
     def create_file(self, marker: MeasStartMarker):
         self.oflcorrection = 0

--- a/src/multiharp_toolkit/stream_parser.py
+++ b/src/multiharp_toolkit/stream_parser.py
@@ -16,7 +16,7 @@ from queue import Empty, Queue
 
 
 class StreamParser:
-    oflcorrection: float
+    oflcorrection: int
     config: DeviceConfig | None
     queue_send: asyncio.Queue[ParsedMeasDataSequence]
     """queue for sending the data to next step"""
@@ -90,7 +90,7 @@ class StreamParser:
                 ts_arr = []
             self.queue_recv.task_done()
 
-    def timetag2time(self, timetag: float) -> float:
+    def timetag2time(self, timetag: int) -> int:
         """convert time tag to time(unit: psec)
         """
         return timetag * self.time_resolution

--- a/src/multiharp_toolkit/stream_parser.py
+++ b/src/multiharp_toolkit/stream_parser.py
@@ -71,11 +71,11 @@ class StreamParser:
                         if channel == 0:  # sync
                             truetime = self.oflcorrection + timetag
                             ch_arr.append(channel)
-                            ts_arr.append(self.timetag2time(truetime))
+                            ts_arr.append(self.convert_timetag_to_relative_timestamp(truetime))
                     else:  # regular input channel
                         truetime = self.oflcorrection + timetag
                         ch_arr.append(channel + 1)
-                        ts_arr.append(self.timetag2time(truetime))
+                        ts_arr.append(self.convert_timetag_to_relative_timestamp(truetime))
             if ch_arr:
                 batch = pa.record_batch(
                     [
@@ -90,8 +90,8 @@ class StreamParser:
                 ts_arr = []
             self.queue_recv.task_done()
 
-    def timetag2time(self, timetag: int) -> int:
-        """convert time tag to time(unit: psec)
+    def convert_timetag_to_relative_timestamp(self, timetag: int) -> int:
+        """Convert a time tag to a relative timestamp with picosecond resolution.
         """
         return timetag * self.time_resolution
 

--- a/src/multiharp_toolkit/stream_parser.py
+++ b/src/multiharp_toolkit/stream_parser.py
@@ -35,6 +35,7 @@ class StreamParser:
         self.oflcorrection = 0
         self.config = None
         self.single_file = single_file
+        self.globRes = 5  # TODO: Neet to get from MultiHarp settings
 
     async def run(self):
         while True:
@@ -70,11 +71,11 @@ class StreamParser:
                         if channel == 0:  # sync
                             truetime = self.oflcorrection + timetag
                             ch_arr.append(channel)
-                            ts_arr.append(truetime * 5)
+                            ts_arr.append(self.timeidx2time(truetime))
                     else:  # regular input channel
                         truetime = self.oflcorrection + timetag
                         ch_arr.append(channel + 1)
-                        ts_arr.append(truetime * 5)
+                        ts_arr.append(self.timeidx2time(truetime))
             if ch_arr:
                 batch = pa.record_batch(
                     [
@@ -88,6 +89,11 @@ class StreamParser:
                 ch_arr = []
                 ts_arr = []
             self.queue_recv.task_done()
+
+    def timeidx2time(self, timeidx: float) -> float:
+        """convert time index to time(unit: psec)
+        """
+        return timeidx * self.globRes
 
     def create_file(self, marker: MeasStartMarker):
         self.oflcorrection = 0


### PR DESCRIPTION
closes #13 
I named magic number "5", "globRes(resolution)".

Actually, we can get from "MeasDesc_GlobalResolution" when we use ptu_parser.
But, I can not check the actual operation now, so I put a constant value.