### PR TITLE
Multiharp shared library automatic installation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,36 +1,90 @@
 use std::env;
+use std::env::VarError;
+use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=wrapper.h");
     let os = env::consts::OS;
     let arch = env::consts::ARCH;
     if arch != "x86_64" || (os != "linux" && os != "windows") {
-        return;
+        panic!("Only x86_64 Linux or Windows is supported.");
     }
-    let mut lib_dir = String::from("");
-    if os == "linux" {
-        // this requires the MHLib_v3.x.x_64bit directory to be in the same directory as the Cargo.toml file
-        let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
 
-        // if the MHLIB_PATH environment variable is provided, use it
-        let lib_dir_path = env::var("MHLIB_PATH").map_or(
-            PathBuf::from(manifest_dir).join("MHLib_v3.1.0.0_64bit/library"),
-            PathBuf::from,
-        );
-        assert!(
-            lib_dir_path.exists(),
-            "Library directory does not exist: {}",
-            lib_dir_path.display()
-        );
-        lib_dir = lib_dir_path.to_string_lossy().into_owned();
-        println!("cargo:rustc-link-search={}", lib_dir);
+    let mut include_dir = String::from("not_found");
+    let mut lib_dir_path: PathBuf;
+    if os == "linux" {
+        // locate the lib dir or download the files if necessary
+        match env::var("MHLIB_LIB_DIR") {
+            Ok(val) => {
+                // the environment variable takes priority over all else
+                lib_dir_path = PathBuf::from(val);
+                assert!(
+                    lib_dir_path.exists(),
+                    "MHLIB_LIB_DIR was set, but the path does not seem to exist. Don't know what to do, exiting. Value was: {}",
+                    lib_dir_path.display()
+                );
+            }
+            Err(e) => match e {
+                VarError::NotPresent => {
+                    // Check the directory holding the Cargo.toml file to see if
+                    // someone manually placed the library there.
+                    let manifest_dir =
+                        env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+                    lib_dir_path =
+                        PathBuf::from(manifest_dir.clone()).join("MHLib_v3.1.0.0_64bit/library");
+
+                    if !lib_dir_path.exists() {
+                        // Check to see if it was installed systemwide.
+                        lib_dir_path = PathBuf::from("/usr/local/lib/mh150");
+                        if !lib_dir_path.exists() {
+                            // Download it ourselves.
+                            Command::new(
+                                PathBuf::from(manifest_dir)
+                                    .join("install_mhlib.sh")
+                                    .as_os_str(),
+                            )
+                            .output()
+                            .expect("mhlib download failed");
+                        }
+                    }
+                }
+                unknown_error => {
+                    panic!("Unknown error occurred trying to read the MHLIB_PATH environment variable, are you sure this is Linux? Error: {unknown_error}");
+                }
+            },
+        }
+
+        let lib_dir = lib_dir_path.to_string_lossy().into_owned();
+        if lib_dir_path.join("mhlib.h").exists() {
+            include_dir = lib_dir.clone();
+        } else {
+            // Most likely someone decided to properly separate header
+            // files into the system include directory.
+            let include_dir_path = Path::new("/usr/local/include/mh150");
+            assert!(
+                include_dir_path.exists(),
+                "Could not find header files in the lib_dir {}, tried to find them in the include_dir {} instead but this directory also appears to be missing. Don't know what to do; exiting.",
+                lib_dir_path.display(),
+                include_dir_path.display(),
+            );
+            include_dir = include_dir_path.to_string_lossy().into_owned();
+        }
+
+        println!("cargo:rustc-link-search=native={}", lib_dir);
         println!("cargo:rustc-link-lib=dylib=mhlib");
         println!("cargo:rustc-link-arg=-Wl,-rpath={}", lib_dir);
-    }
+    } else if os == "windows" {
+        include_dir = String::from("C:\\Program Files\\PicoQuant\\MultiHarp-MHLibv31");
+        let lib_dir = include_dir.clone();
 
-    if os == "windows" {
-        lib_dir = String::from("C:\\Program Files\\PicoQuant\\MultiHarp-MHLibv31");
+        assert!(
+            Path::new(&include_dir).exists(),
+            "Include and library directory does not exist: {}",
+            include_dir
+        );
+
         println!("cargo:rustc-link-search=native={}", lib_dir);
         println!("cargo:rustc-link-lib=dylib=mhlib64");
     }
@@ -42,7 +96,7 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
-        .clang_arg(format!("-I{}", lib_dir))
+        .clang_arg(format!("-I{}", include_dir))
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -7,6 +7,7 @@
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
+#   universal: false
 
 -e file:.
 asttokens==2.4.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -7,6 +7,7 @@
 #   all-features: false
 #   with-sources: false
 #   generate-hashes: false
+#   universal: false
 
 -e file:.
 kaleido==0.2.1


### PR DESCRIPTION
One of the more difficult hurdles to working with multiharp-toolkit has been installing [the proprietary shared C library provided by PicoQuant](https://www.picoquant.com/products/category/tcspc-and-time-tagging-modules/multiharp-150-high-throughput-multichannel-event-timer-tcspc-unit#custom1) and creating Rust and Python bindings for it.

Previously, `build.rs` would check if the `MHLIB_LIB_DIR` environment variable was set, and look there for the library and its header files. If this was not set, it would look in this respository's root directory for the library.

This worked OK for multiharp-toolkit when built as a top-level, standalone project. However, it did not work well when multiharp-toolkit was included as a dependency of another project.

The search logic is now much more complex, and should always succeed as long as the PicoQuant homepage is available.

In order, the following locations are checked for the library and its headers:

* `MHLIB_LIB_DIR`
* `CARGO_MANIFEST_DIR/MHLib_v3.1.0.0_64bit/library`
* `/usr/local/lib/mh150`
* If none of these locations are available, automatically download the library from PicoQuant. The download script will cache the full download to speed up future builds.

It also allows for header files to be placed in a separate `include` directory, following common Unix conventions.

Behavior on Windows remains the same as it was before.

This Rust code is not good. In fact, it's not very good code in any programming language. I will create an issue to track refactoring it to be more understandable and idiomatically Rust. (Edit: this issue https://github.com/moonshot-nagayama-pj/multiharp-toolkit/issues/15)

However, I have tested all of the different Linux code paths, and I think it is sufficiently functional for now.