### PR TITLE
Ensure that the .arrows directory exists

### DIFF
--- a/src/multiharp_toolkit/cmd.py
+++ b/src/multiharp_toolkit/cmd.py
@@ -78,7 +78,7 @@ def ptu2arrow():
     )
 
     if not args.parquet and os.path.exists(arrow_file_path):
-        print("arrow file is alread exist:", arrow_file_path)
+        print("arrow file already exists: ", arrow_file_path)
         exit(0)
 
     if not os.path.exists(".arrows"):

--- a/src/multiharp_toolkit/stream_parser.py
+++ b/src/multiharp_toolkit/stream_parser.py
@@ -97,6 +97,7 @@ class StreamParser:
 
     def create_file(self, marker: MeasStartMarker):
         self.oflcorrection = 0
+        os.mkdirs(".arrows", 0o755, exist_ok=True)
         filename = os.path.join(
             ".arrows", f"{int(time.time())}-{marker.measurement_duration}.arrow"
         )


### PR DESCRIPTION
During testing of multiharp-node, which depends on this class, we found that it was failing because the `.arrows` directory did not exist inside the service's working directory.

Eventually, we will need to stop hard-coding this value.