### PR TITLE
Add histogramming

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -1,0 +1,3 @@
+//! Intermediate pipeline components that perform some kind of histogramming operation.
+
+pub mod time_bin;

--- a/src/histogram/time_bin.rs
+++ b/src/histogram/time_bin.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+use std::sync::mpsc::{Receiver, Sender};
+
+use crate::types::NormalizedTimeTag;
+
+pub fn time_bin(
+    receiver: Receiver<Vec<NormalizedTimeTag>>,
+    mut sender: Sender<TimeBin>,
+) -> Result<()> {
+    todo!("Implement this function")
+}
+
+pub struct TimeBin {}

--- a/src/histogram/time_bin.rs
+++ b/src/histogram/time_bin.rs
@@ -6,10 +6,7 @@ use crate::types::NormalizedTimeTag;
 
 const BIN_WIDTH_PS: u64 = 1_000_000; // example: 1 microsecond = 1,000,000 ps
 
-pub fn time_bin(
-    receiver: Receiver<Vec<NormalizedTimeTag>>,
-    sender: Sender<TimeBin>,
-) -> Result<()> {
+pub fn time_bin(receiver: Receiver<Vec<NormalizedTimeTag>>, sender: Sender<TimeBin>) -> Result<()> {
     let mut current_bin_start: Option<u64> = None;
     let mut current_counts: HashMap<u16, u64> = HashMap::new();
 

--- a/src/histogram/time_bin.rs
+++ b/src/histogram/time_bin.rs
@@ -6,7 +6,10 @@ use crate::types::NormalizedTimeTag;
 
 const BIN_WIDTH_PS: u64 = 1_000_000; // example: 1 microsecond = 1,000,000 ps
 
-pub fn time_bin(receiver: Receiver<Vec<NormalizedTimeTag>>, sender: Sender<TimeBin>) -> Result<()> {
+pub fn time_bin(
+    receiver: Receiver<Vec<NormalizedTimeTag>>,
+    sender: &Sender<TimeBin>,
+) -> Result<()> {
     let mut current_bin_start: Option<u64> = None;
     let mut current_counts: HashMap<u16, u64> = HashMap::new();
 
@@ -44,7 +47,7 @@ pub fn time_bin(receiver: Receiver<Vec<NormalizedTimeTag>>, sender: Sender<TimeB
                 }
                 Some(_) => {
                     // older event arrived after newer ones
-                    // for now, just ignore this case because input is expected to be time-ordered
+                    continue;
                 }
             }
 
@@ -64,6 +67,7 @@ pub fn time_bin(receiver: Receiver<Vec<NormalizedTimeTag>>, sender: Sender<TimeB
     Ok(())
 }
 
+#[derive(Debug)]
 pub struct TimeBin {
     pub start_time_ps: u64,
     pub end_time_ps: u64,

--- a/src/histogram/time_bin.rs
+++ b/src/histogram/time_bin.rs
@@ -1,13 +1,74 @@
 use anyhow::Result;
+use std::collections::HashMap;
 use std::sync::mpsc::{Receiver, Sender};
 
 use crate::types::NormalizedTimeTag;
 
+const BIN_WIDTH_PS: u64 = 1_000_000; // example: 1 microsecond = 1,000,000 ps
+
 pub fn time_bin(
     receiver: Receiver<Vec<NormalizedTimeTag>>,
-    mut sender: Sender<TimeBin>,
+    sender: Sender<TimeBin>,
 ) -> Result<()> {
-    todo!("Implement this function")
+    let mut current_bin_start: Option<u64> = None;
+    let mut current_counts: HashMap<u16, u64> = HashMap::new();
+
+    for batch in receiver {
+        for event in batch {
+            let event_bin_start = (event.time_tag_ps / BIN_WIDTH_PS) * BIN_WIDTH_PS;
+
+            match current_bin_start {
+                None => {
+                    current_bin_start = Some(event_bin_start);
+                }
+                Some(start) if event_bin_start == start => {
+                    // same bin, continue
+                }
+                Some(start) if event_bin_start > start => {
+                    // flush current bin
+                    sender.send(TimeBin {
+                        start_time_ps: start,
+                        end_time_ps: start + BIN_WIDTH_PS,
+                        counts: std::mem::take(&mut current_counts),
+                    })?;
+
+                    // if there are skipped bins, emit empty ones too
+                    let mut next_start = start + BIN_WIDTH_PS;
+                    while next_start < event_bin_start {
+                        sender.send(TimeBin {
+                            start_time_ps: next_start,
+                            end_time_ps: next_start + BIN_WIDTH_PS,
+                            counts: HashMap::new(),
+                        })?;
+                        next_start += BIN_WIDTH_PS;
+                    }
+
+                    current_bin_start = Some(event_bin_start);
+                }
+                Some(_) => {
+                    // older event arrived after newer ones
+                    // for now, just ignore this case because input is expected to be time-ordered
+                }
+            }
+
+            *current_counts.entry(event.channel_id).or_insert(0) += 1;
+        }
+    }
+
+    // flush the last bin after the channel closes
+    if let Some(start) = current_bin_start {
+        sender.send(TimeBin {
+            start_time_ps: start,
+            end_time_ps: start + BIN_WIDTH_PS,
+            counts: current_counts,
+        })?;
+    }
+
+    Ok(())
 }
 
-pub struct TimeBin {}
+pub struct TimeBin {
+    pub start_time_ps: u64,
+    pub end_time_ps: u64,
+    pub counts: HashMap<u16, u64>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //!
 //! For now, the best example of a complete pipeline is probably the `tdc_toolkit` CLI implementation.
 
+pub mod histogram;
 pub mod multiharp;
 pub mod output;
 pub mod types;


### PR DESCRIPTION
This PR adds a time binning function that aggregates NormalizedTimeTag events into fixed time windows and counts photon arrivals per channel. Each TimeBin contains:
- start_time_ps
- end_time_ps
- photon counts per channel

This will allow for monitoring of single counts and will provide for histogramming and further analysis. 