### PR TITLE
Update PicoQuant download URL

### DIFF
--- a/install_mhlib.sh
+++ b/install_mhlib.sh
@@ -99,7 +99,7 @@ function validate_hash() {
 function download() {
   if ! [[ -f "${cached_zip_file}" ]]; then
     mkdir -p "${cache_dir}"
-    curl --output "${cached_zip_file}" 'https://www.picoquant.com/dl_software/MultiHarp150/'"${zip_file}"
+    curl --output "${cached_zip_file}" 'https://downloads.picoquant.com/software/MultiHarp150/'"${zip_file}"
   fi
   validate_hash "${cached_zip_file}" "${zip_sha3_512}"
 }


### PR DESCRIPTION
@EliottFlechtner noticed while working on https://github.com/moonshot-nagayama-pj/tdc_toolkit/issues/39 that the hash had changed for the MultiHarp software download -- it turns out that the file itself was relocated to a new download server when PicoQuant's website was redesigned recently (and we were now hashing a 404 page).