### PR TITLE
feat: implement version command

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,25 @@ fn main() {
     let os = env::consts::OS;
     let arch = env::consts::ARCH;
 
+    // Provide compiling information for version command
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string());
+    println!("cargo:rustc-env=TDC_TOOLKIT_GIT_REF={git_hash}");
+
+    let rustc_version = Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map_or_else(|| "unknown".to_string(), |s| s.trim().to_string());
+    println!("cargo:rustc-env=TDC_TOOLKIT_RUSTC_VERSION={rustc_version}");
+
+    println!("cargo::rerun-if-changed=.git/HEAD");
+
     if cfg!(not(feature = "multiharp")) {
         println!("cargo::warning=Using the mhlib_wrapper stub implementation.");
         return;

--- a/src/bin/tdc_toolkit.rs
+++ b/src/bin/tdc_toolkit.rs
@@ -84,6 +84,19 @@ enum Command {
         #[arg(long, default_value_t = String::from("record"))]
         name: String,
     },
+
+    /// Print version information
+    ///
+    /// This command outputs a JSON object with the following fields:
+    ///
+    /// * `tdc_toolkit_version`: The version of this CLI
+    ///
+    /// * `tdc_toolkit_git_ref`: The git reference
+    ///
+    /// * `mhlib_version`: The version of MHLib (or "Stub")
+    ///
+    /// * `rust_version`: The rustc compiler version used to build this CLI
+    Version,
 }
 
 #[cfg(feature = "multiharp")]
@@ -244,6 +257,11 @@ fn main() -> Result<()> {
             }
 
             progress_bar.finish_with_message("Recording complete");
+            Ok(())
+        }
+        Command::Version => {
+            let version_info = tdc_toolkit::version::get_version();
+            println!("{}", serde_json::to_string_pretty(&version_info)?);
             Ok(())
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod multiharp;
 pub mod output;
 pub mod types;
+pub mod version;
 
 #[cfg(feature = "python")]
 mod python_api;

--- a/src/version.rs
+++ b/src/version.rs
@@ -19,7 +19,6 @@ pub fn get_version() -> Version {
     }
 }
 
-// TODO: unverified, needs testing on physical hardware
 #[cfg(feature = "multiharp")]
 fn get_mhlib_version_from_wrapper() -> String {
     if let Ok(wrapper) = crate::multiharp::mhlib_wrapper::real::MhlibWrapperReal::new(0) {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,40 @@
+use crate::multiharp::mhlib_wrapper::meta::MhlibWrapper;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Version {
+    pub tdc_toolkit_version: String,
+    pub tdc_toolkit_git_ref: String,
+    pub mhlib_version: String,
+    pub rust_version: String,
+}
+
+#[must_use]
+pub fn get_version() -> Version {
+    Version {
+        tdc_toolkit_version: env!("CARGO_PKG_VERSION").to_string(),
+        tdc_toolkit_git_ref: env!("TDC_TOOLKIT_GIT_REF").to_string(),
+        rust_version: env!("TDC_TOOLKIT_RUSTC_VERSION").to_string(),
+        mhlib_version: get_mhlib_version_from_wrapper(),
+    }
+}
+
+// TODO: unverified, needs testing on physical hardware
+#[cfg(feature = "multiharp")]
+fn get_mhlib_version_from_wrapper() -> String {
+    if let Ok(wrapper) = crate::multiharp::mhlib_wrapper::real::MhlibWrapperReal::new(0) {
+        wrapper
+            .get_library_version()
+            .unwrap_or_else(|_| "unknown".to_string())
+    } else {
+        "unknown".to_string()
+    }
+}
+
+#[cfg(not(feature = "multiharp"))]
+fn get_mhlib_version_from_wrapper() -> String {
+    let wrapper = crate::multiharp::mhlib_wrapper::stub::MhlibWrapperStub::new(0);
+    wrapper
+        .get_library_version()
+        .unwrap_or_else(|_| "unknown".to_string())
+}


### PR DESCRIPTION
Feat for #38 

Modification: 
- `build.rs` Injected `TDC_TOOLKIT_GIT_REF` and `TDC_TOOLKIT_RUSTC_VERSION` into env var. 
- Version logic in `src/version.rs`
- `src/bin/tdc_toolkit.rs`: registered the command