### PR TITLE
Refactor thread error handling code into a common function

### DIFF
--- a/src/bin/tdc_toolkit.rs
+++ b/src/bin/tdc_toolkit.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Error, Result, bail};
+use anyhow::{Context, Error, Result};
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::fs;
@@ -19,6 +19,7 @@ use tdc_toolkit::multiharp::mhlib_wrapper::real::MhlibWrapperReal;
 
 use tdc_toolkit::multiharp::mhlib_wrapper::stub::MhlibWrapperStub;
 use tdc_toolkit::multiharp::recording;
+use tdc_toolkit::util::join_and_collect_thread_errors;
 
 #[derive(Debug, Parser)]
 #[command(name = "tdc_toolkit")]
@@ -238,24 +239,10 @@ fn main() -> Result<()> {
                 thread::sleep(Duration::from_millis(100));
             }
 
-            let recording_thread_name = recording_thread
-                .thread()
-                .name()
-                .unwrap_or("unnamed")
-                .to_owned();
-            if let Err(recording_panic) = recording_thread.join() {
-                if let Ok(recording_panic_anyhow) = recording_panic.downcast::<Error>() {
-                    bail!(
-                        "Error returned from thread {}:\n{:?}",
-                        recording_thread_name,
-                        recording_panic_anyhow
-                    );
-                }
-                panic!(
-                    "Failed downcast of thread {recording_thread_name} error result to anyhow::Error. This should not happen. Threads in this application should always return anyhow::Error."
-                );
-            }
-
+            match join_and_collect_thread_errors(vec![recording_thread]) {
+                None => Ok(()),
+                Some(error) => Err(error),
+            }?;
             progress_bar.finish_with_message("Recording complete");
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod multiharp;
 pub mod output;
 pub mod types;
+pub mod util;
 pub mod version;
 
 #[cfg(feature = "python")]

--- a/src/multiharp/recording.rs
+++ b/src/multiharp/recording.rs
@@ -1,5 +1,4 @@
-use anyhow::{Error, Result, anyhow};
-use std::fmt::Write;
+use anyhow::Result;
 use std::panic::panic_any;
 use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
@@ -9,29 +8,7 @@ use std::time::Duration;
 use super::device::MH160;
 use super::tttr_record;
 use crate::output::parquet;
-
-fn join_and_collect_thread_errors<T>(handles: Vec<thread::JoinHandle<T>>) -> Option<Error> {
-    let mut error_str = String::new();
-    for handle in handles {
-        let thread_name = handle.thread().name().unwrap_or("unnamed").to_owned();
-        if let Err(thread_panic) = handle.join() {
-            if let Ok(thread_panic_anyhow) = thread_panic.downcast::<Error>() {
-                let _ = write!(
-                    error_str,
-                    "Error returned from thread {thread_name}:\n{thread_panic_anyhow:?}\n----------\n",
-                );
-            } else {
-                panic!(
-                    "Failed downcast to anyhow::Error. This should not happen. Threads in this application should always return anyhow::Error."
-                );
-            }
-        }
-    }
-    if error_str.is_empty() {
-        return None;
-    }
-    Some(anyhow!("Error in one or more threads.").context(error_str))
-}
+use crate::util::join_and_collect_thread_errors;
 
 pub fn record_multiharp_to_parquet(
     device: Arc<dyn MH160 + Send + Sync>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,32 @@
+use anyhow::{Error, anyhow};
+use std::fmt::Write;
+use std::thread;
+
+/// Utility function for keeping track of errors that originate in worker threads.
+///
+/// # Panics
+///
+/// Panics in threads joined by this function will cause panics here.
+#[must_use]
+pub fn join_and_collect_thread_errors<T>(handles: Vec<thread::JoinHandle<T>>) -> Option<Error> {
+    let mut error_str = String::new();
+    for handle in handles {
+        let thread_name = handle.thread().name().unwrap_or("unnamed").to_owned();
+        if let Err(thread_panic) = handle.join() {
+            if let Ok(thread_panic_anyhow) = thread_panic.downcast::<Error>() {
+                let _ = write!(
+                    error_str,
+                    "Error returned from thread {thread_name}:\n{thread_panic_anyhow:?}\n----------\n",
+                );
+            } else {
+                panic!(
+                    "Failed downcast to anyhow::Error. This should not happen. Threads in this application should always return anyhow::Error."
+                );
+            }
+        }
+    }
+    if error_str.is_empty() {
+        return None;
+    }
+    Some(anyhow!("Error in one or more threads.").context(error_str))
+}


### PR DESCRIPTION
Contributes to https://github.com/moonshot-nagayama-pj/tdc_toolkit/issues/41

This does not solve the logic problems described in https://github.com/moonshot-nagayama-pj/tdc_toolkit/issues/41 and I expect that the function signature will change. I'm not sure why I used an `Option` rather than a `Result` when coding this originally.

However, this moves the code into a public function that can be used in other places.