### PR TITLE
Thread error handling changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["tdc", "multiharp", "physics", "quantum"]
 categories = ["api-bindings", "command-line-utilities", "date-and-time", "science"]
 links = "mhlib"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.95"
 exclude = [
     ".devcontainer",
     ".editorconfig",

--- a/src/bin/tdc_toolkit.rs
+++ b/src/bin/tdc_toolkit.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Error, Result};
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::fs;
-use std::panic::panic_any;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -218,7 +217,7 @@ fn main() -> Result<()> {
                         name,
                     ) {
                         recording_failed_thread_clone.store(true, Ordering::Relaxed);
-                        panic_any(recording_error);
+                        return Err(recording_error);
                     }
                     Ok(())
                 })?;

--- a/src/bin/tdc_toolkit.rs
+++ b/src/bin/tdc_toolkit.rs
@@ -239,10 +239,7 @@ fn main() -> Result<()> {
                 thread::sleep(Duration::from_millis(100));
             }
 
-            match join_and_collect_thread_errors(vec![recording_thread]) {
-                None => Ok(()),
-                Some(error) => Err(error),
-            }?;
+            join_and_collect_thread_errors(vec![recording_thread])?;
             progress_bar.finish_with_message("Recording complete");
             Ok(())
         }

--- a/src/multiharp/recording.rs
+++ b/src/multiharp/recording.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use std::panic::panic_any;
 use std::path::PathBuf;
 use std::sync::{Arc, mpsc};
 use std::thread;
@@ -21,25 +20,16 @@ pub fn record_multiharp_to_parquet(
 
     let mut handles = Vec::new();
 
-    let device_thread =
-        thread::Builder::new()
-            .name("device_thread".into())
-            .spawn(move || -> Result<()> {
-                if let Err(error) = device.stream_measurement(&duration, raw_send_channel) {
-                    panic_any(error);
-                }
-                Ok(())
-            })?;
+    let device_thread = thread::Builder::new()
+        .name("device_thread".into())
+        .spawn(move || -> Result<()> { device.stream_measurement(&duration, raw_send_channel) })?;
     handles.push(device_thread);
 
     let processor_thread = thread::Builder::new()
         .name("processor_thread".into())
         .spawn(move || -> Result<()> {
             let mut processor = tttr_record::T2RecordChannelProcessor::new();
-            if let Err(error) = processor.process(raw_receive_channel, processed_send_channel) {
-                panic_any(error);
-            }
-            Ok(())
+            processor.process(raw_receive_channel, processed_send_channel)
         })?;
     handles.push(processor_thread);
 
@@ -48,10 +38,7 @@ pub fn record_multiharp_to_parquet(
             .name("writer_thread".into())
             .spawn(move || -> Result<()> {
                 let writer = parquet::TimeTagStreamParquetWriter::new();
-                if let Err(error) = writer.write(processed_receive_channel, &output_dir, &name) {
-                    panic_any(error);
-                }
-                Ok(())
+                writer.write(processed_receive_channel, &output_dir, &name)
             })?;
     handles.push(writer_thread);
 

--- a/src/multiharp/recording.rs
+++ b/src/multiharp/recording.rs
@@ -55,8 +55,5 @@ pub fn record_multiharp_to_parquet(
             })?;
     handles.push(writer_thread);
 
-    match join_and_collect_thread_errors(handles) {
-        None => Ok(()),
-        Some(error) => Err(error),
-    }
+    join_and_collect_thread_errors(handles)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, anyhow};
+use anyhow::{Result, bail};
 use std::fmt::Write;
 use std::thread;
 
@@ -7,26 +7,31 @@ use std::thread;
 /// # Panics
 ///
 /// Panics in threads joined by this function will cause panics here.
-#[must_use]
-pub fn join_and_collect_thread_errors<T>(handles: Vec<thread::JoinHandle<T>>) -> Option<Error> {
+pub fn join_and_collect_thread_errors(handles: Vec<thread::JoinHandle<Result<()>>>) -> Result<()> {
     let mut error_str = String::new();
+    let mut unexpected_panic: Option<Box<dyn std::any::Any + Send>> = None;
+
     for handle in handles {
         let thread_name = handle.thread().name().unwrap_or("unnamed").to_owned();
-        if let Err(thread_panic) = handle.join() {
-            if let Ok(thread_panic_anyhow) = thread_panic.downcast::<Error>() {
-                let _ = write!(
-                    error_str,
-                    "Error returned from thread {thread_name}:\n{thread_panic_anyhow:?}\n----------\n",
-                );
-            } else {
-                panic!(
-                    "Failed downcast to anyhow::Error. This should not happen. Threads in this application should always return anyhow::Error."
-                );
+        match handle.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                let _ = write!(error_str, "Error in thread {thread_name}:\n{e:?}\n---\n");
             }
+            Err(payload) => {
+                // Store first unexpected panic; keep joining remaining threads.
+                if unexpected_panic.is_none() {
+                    unexpected_panic = Some(payload);
+                }
+            }
+        }
+
+        if let Some(payload) = unexpected_panic {
+            std::panic::resume_unwind(payload);
         }
     }
     if error_str.is_empty() {
-        return None;
+        return Ok(());
     }
-    Some(anyhow!("Error in one or more threads.").context(error_str))
+    bail!("Errors in one or more threads: {error_str}")
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use std::fmt::Write;
 use std::thread;
 
 /// Utility function for keeping track of errors that originate in worker threads.
@@ -9,29 +8,46 @@ use std::thread;
 /// Panics in threads joined by this function will cause panics here.
 pub fn join_and_collect_thread_errors(handles: Vec<thread::JoinHandle<Result<()>>>) -> Result<()> {
     let mut error_str = String::new();
-    let mut unexpected_panic: Option<Box<dyn std::any::Any + Send>> = None;
+    let mut panic_str = String::new();
 
     for handle in handles {
         let thread_name = handle.thread().name().unwrap_or("unnamed").to_owned();
         match handle.join() {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
-                let _ = write!(error_str, "Error in thread {thread_name}:\n{e:?}\n---\n");
+                error_str = format!("{error_str}Error in thread {thread_name}:\n{e:?}\n---\n");
             }
-            Err(payload) => {
-                // Store first unexpected panic; keep joining remaining threads.
-                if unexpected_panic.is_none() {
-                    unexpected_panic = Some(payload);
+            Err(payload) => match payload.downcast_ref::<String>() {
+                Some(payload_string) => {
+                    panic_str = format!(
+                        "{panic_str}Panic in thread {thread_name}:\n{payload_string}\n---\n"
+                    );
                 }
-            }
+                None => match payload.downcast_ref::<&str>() {
+                    Some(payload_string) => {
+                        panic_str = format!(
+                            "{panic_str}Panic in thread {thread_name}:\n{payload_string}\n---\n"
+                        );
+                    }
+                    None => {
+                        panic_str = format!(
+                            "{panic_str}Panic in thread {thread_name}:\nPanic payload was not downcastable to String or &str\n---\n"
+                        );
+                    }
+                },
+            },
         }
 
-        if let Some(payload) = unexpected_panic {
-            std::panic::resume_unwind(payload);
+        if !panic_str.is_empty() {
+            if !error_str.is_empty() {
+                panic_str =
+                    format!("{panic_str}Additionally, threads returned errors:\n---\n{error_str}");
+            }
+            std::panic::resume_unwind(Box::new(panic_str));
         }
     }
     if error_str.is_empty() {
         return Ok(());
     }
-    bail!("Errors in one or more threads: {error_str}")
+    bail!("Errors in one or more threads: {}", error_str)
 }


### PR DESCRIPTION
Closes https://github.com/moonshot-nagayama-pj/tdc_toolkit/issues/41

@EliottFlechtner may be of interest to you

Refactored thread error collection and propagation.

Using this scheme:

* If a thread returns an error, that error's `Debug` string will be concatenated with any other errors from other threads. That error string will then be returned in the top-level thread managing those other threads.
* If a thread panics, that panic's error message, if any, will be concatenated with any other panic or error messages from other threads before `resume_unwind` is called to propagate the panic upward in the application. In other words, the thread that managed these threads will also panic. As long as we use `join_and_collect_thread_errors` in all places we spawn threads, this means that the application itself will also panic; this is our desired behavior.

`anyhow` errors can contain a value called `context`; this can contain another error that caused this error. When printing the error's debug representation, this additional context is also included, however, I don't think that `anyhow` recurses into the context stack to print all causes. We are not implementing this manually here, so it's possible some context will still be lost.
